### PR TITLE
Add `FromRef` constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ To declare an empty optional value do:
 empty := None[int]()
 ```
 
+To convert pointer into optional value do:
+
+```go
+var pointer *int
+myOption := FromRef(pointer) // empty, if pointer is nil
+```
+
 To check if an optional value is present do:
 
 ```go

--- a/option.go
+++ b/option.go
@@ -71,6 +71,15 @@ func None[T any]() Option[T] {
   }
 }
 
+// FromRef returns an Option whose underlying value is present if t is not nil.
+// Otherwise, it returns an empty optional value.
+func FromRef[T any](t *T) Option[T] {
+  if t == nil {
+    return None[T]()
+  }
+  return Some(*t)
+}
+
 // Apply f to the optional value.
 func Apply[In, Out any](in Option[In], f func(In) Out) Option[Out] {
   if !in.ok {

--- a/option_test.go
+++ b/option_test.go
@@ -163,3 +163,22 @@ func TestRef(t *testing.T) {
     t.Errorf("Failed unwrapping option ref, expected 4 but got %d", unwrapped)
   }
 }
+
+func TestFromRef(t *testing.T) {
+  empty := FromRef((*int)(nil))
+  if empty.Ok() {
+    t.Errorf("FromRef must be empty for nil")
+  }
+
+  val := 10
+  ptr := &val
+  myOption := FromRef(ptr)
+
+  if !myOption.Ok() {
+    t.Errorf("FromRef must be present for non-nil value")
+  }
+
+  if unwrapped := myOption.Unwrap(); unwrapped != 10 {
+    t.Errorf("FromRef must contain dereferenced value, expected 10 but got %d", unwrapped)
+  }
+}


### PR DESCRIPTION
This PR adds `FromRef` constructor to create optional value from pointer.
It will be useful, for example, to transform optional protobuf fields.